### PR TITLE
Update to new Vexim: spam move action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,31 @@
-Roundcube VeximAccountAdmin plugin: CHANGELOG
-=============================================
+# Roundcube VeximAccountAdmin plugin: CHANGELOG #
+
+2015-11-07
+
+* First support for Vexim 2
+* Italian language
 
 2009-11-24
-----------
- * French language (thanks Bertrand Cherrier)
+
+* French language (thanks Bertrand Cherrier)
 
 2009-11-12
-----------
- * Added support for maximum autoresponder message length
-   (if upgrading, copy the new variable from config dist file to your
-   config file if you want to change from default setting)
+
+* Added support for maximum autoresponder message length
+  (if upgrading, copy the new variable from config dist file to your
+  config file if you want to change from default setting)
 
 2009-11-06
-----------
- * Changed CSS class for box header (got broken i Roundcube 0.3.1)
- * Display success message on saving also when no changes are made
+
+* Changed CSS class for box header (got broken i Roundcube 0.3.1)
+* Display success message on saving also when no changes are made
 
 2009-10-19
-----------
- * Fixed typo causing plugin to use global load_config
-   instead of _load_config on form display
+
+* Fixed typo causing plugin to use global load_config
+  instead of _load_config on form display
 
 2009-09-25
-----------
- * First public release
- * English and Norwegian languages
+
+* First public release
+* English and Norwegian languages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,27 @@
 Roundcube VeximAccountAdmin plugin: CHANGELOG
-Last updated: 2009-11-12
-===========================================
+=============================================
+
+2009-11-24
+----------
+ * French language (thanks Bertrand Cherrier)
 
 2009-11-12
-==========
+----------
  * Added support for maximum autoresponder message length
    (if upgrading, copy the new variable from config dist file to your
    config file if you want to change from default setting)
 
 2009-11-06
-==========
+----------
  * Changed CSS class for box header (got broken i Roundcube 0.3.1)
  * Display success message on saving also when no changes are made
 
 2009-10-19
-==========
+----------
  * Fixed typo causing plugin to use global load_config
    instead of _load_config on form display
 
 2009-09-25
-==========
+----------
  * First public release
- 
-
-===========================================
-Roundcube VeximAccountAdmin plugin: LANGUAGES
-Last updated: 2009-11-24
-===========================================
-
-Languages are added to the package as soon as they arrive.
-
- * 2009-11-24: French (thanks Bertrand Cherrier)
- * 2009-09-25: English and Norwegian
+ * English and Norwegian languages

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-Roundcube VeximAccountAdmin plugin: README
-Last updated: 2009-11-12
-===========================================
+Roundcube VeximAccountAdmin plugin
+==================================
 
 About
-================
+----
 
-Plugin that covers the non-admin part of Vexim web interface.
+A RoundCube plugin allowing users to manage non-administrative settings
+of Vexim, without the need to login again in its web interface.
 
 Possible future versions will be posted to:
 http://axel.sjostedt.no/misc/dev/roundcube/
 
 Author
-================
+------
 Written by Axel Sjostedt.
 
 Install
-================
+------
 
 * Place plugin folder into plugins directory of Roundcube
 * Enable the plugin by adding it to the Roundcube configuration file 
@@ -23,7 +23,7 @@ Install
      $rcmail_config['plugins'] = array("veximaccountadmin", "otherplugin")
 
 Configuration 
-================
+------------
 
 * Copy config.inc.php.dist to config.inc.php in the plugin folder
   It is recommended to keep the dist file.
@@ -34,14 +34,14 @@ Configuration
 * Check that the cryptscheme and vexim_vacation_maxlength settings
   is the same as in your Vexim config 
 * If you use any of the Exim/Vexim customizations described on 
-  http://axel.sjostedt.no/misc/dev/vexim-customizations/ (disable saving
-  of passwords in clear text, move spam to folder support, shell spam 
-  parsing script), you should enable support for these in
-  VeximAccountAdmin config.
+  http://axel.sjostedt.no/misc/dev/vexim-customizations/ (move spam to
+  folder support, shell spam parsing script), you should enable support
+  for these in VeximAccountAdmin config.
 * Check that the Vexim URL is correct if you want to provide a Vexim link
   to admin users
 
 Other notes
-================
+----------
+
 If you also want to update your Vexim login page with a Roundcube-like
 design, see http://axel.sjostedt.no/misc/dev/vexim-customizations/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-Roundcube VeximAccountAdmin plugin
-==================================
+# Roundcube VeximAccountAdmin plugin #
 
-About
-----
+## About ##
 
 A RoundCube plugin allowing users to manage non-administrative settings
 of Vexim, without the need to login again in its web interface.
@@ -10,20 +8,19 @@ of Vexim, without the need to login again in its web interface.
 Possible future versions will be posted to:
 http://axel.sjostedt.no/misc/dev/roundcube/
 
-Author
-------
+## Author ##
+
 Written by Axel Sjostedt.
 
-Install
-------
+## Install ##
 
 * Place plugin folder into plugins directory of Roundcube
 * Enable the plugin by adding it to the Roundcube configuration file 
   Example: 
-     $rcmail_config['plugins'] = array("veximaccountadmin", "otherplugin")
+  
+        $rcmail_config['plugins'] = array("veximaccountadmin", "otherplugin")
 
-Configuration 
-------------
+## Configuration ##
 
 * Copy config.inc.php.dist to config.inc.php in the plugin folder
   It is recommended to keep the dist file.
@@ -40,8 +37,7 @@ Configuration
 * Check that the Vexim URL is correct if you want to provide a Vexim link
   to admin users
 
-Other notes
-----------
+## Other notes ##
 
 If you also want to update your Vexim login page with a Roundcube-like
 design, see http://axel.sjostedt.no/misc/dev/vexim-customizations/

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -25,8 +25,6 @@ $veximaccountadmin_config['vexim_vacation_maxlength'] = 255;
 	Support for the Exim/Vexim customizations described on
 	http://axel.sjostedt.no/misc/vexim/
 */
-// Set this to true if you have added the auto spam folder transporters to Vexim/Exim
-$veximaccountadmin_config['movespam_transporter'] = false;
 // Set this to true if you have added the parsefolders shell script
 $veximaccountadmin_config['parsefolders_script'] = false;
 $veximaccountadmin_config['parsefolders_script_show_tip'] = true; // Show notice about learnasspam folders

--- a/veximaccountadmin.php
+++ b/veximaccountadmin.php
@@ -114,9 +114,9 @@ class veximaccountadmin extends rcube_plugin
 		$sa_tag = get_input_value('sa_tag', RCUBE_INPUT_POST);
 		$sa_refuse = get_input_value('sa_refuse', RCUBE_INPUT_POST);
 	
-		$axel_on_movespam = get_input_value('axel_on_movespam', RCUBE_INPUT_POST);
-		if(!$axel_on_movespam)
-			$axel_on_movespam = 0;
+		$spam_drop = get_input_value('spam_drop', RCUBE_INPUT_POST);
+		if(!$spam_drop)
+			$spam_drop = 0;
 	
 		$on_vacation = get_input_value('on_vacation', RCUBE_INPUT_POST);
 		if(!$on_vacation)
@@ -147,7 +147,7 @@ class veximaccountadmin extends rcube_plugin
 		$prefs = $_POST['_headerblock_rule_field'];
 		$vals = $_POST['_headerblock_rule_value'];
 		 
-		$res = $this->_save($user,$on_avscan,$on_spamassassin,$sa_tag,$sa_refuse,$axel_on_movespam,$on_vacation,$vacation,$on_forward,$forward,$unseen,$maxmsgsize,$acts,$prefs,$vals);
+		$res = $this->_save($user,$on_avscan,$on_spamassassin,$sa_tag,$sa_refuse,$spam_drop,$on_vacation,$vacation,$on_forward,$forward,$unseen,$maxmsgsize,$acts,$prefs,$vals);
 		  
 		if (!$res) {
 			$rcmail->output->command('display_message', $this->gettext('savesuccess-config'), 'confirmation');
@@ -187,7 +187,7 @@ class veximaccountadmin extends rcube_plugin
 		$on_spamassassin	= $settings['on_spamassassin'];
 		$sa_tag				= $settings['sa_tag'];
 		$sa_refuse			= $settings['sa_refuse'];
-		$axel_on_movespam	= $settings['axel_on_movespam'];
+		$spam_drop			= $settings['spam_drop'];
 		$on_vacation		= $settings['on_vacation'];
 		$vacation 			= $settings['vacation'];
 		$on_forward			= $settings['on_forward'];
@@ -350,24 +350,20 @@ class veximaccountadmin extends rcube_plugin
 					$input_spamscorerefuse->show($sa_refuse),
 					'<br /><span class="vexim-explanation">' . $this->gettext('spamscorerefuseexplanation') . '. <span class="sameline">' . $this->gettext('domaindefault') . ': ' . $default_sa_refuse . '.</span></span>');		
 
-		if ($this->config['movespam_transporter']) {
-			
-			$spammoveexplanation = '<br /><span class="vexim-explanation">' . str_replace("%italicstart", "<i>", str_replace("%italicend", "</i>", $this->gettext('spammoveexplanation_part1')));
-			if ($this->config['parsefolders_script'])
-				$spammoveexplanation .= ' ' . $this->gettext('spammoveexplanation_part2');
-			$spammoveexplanation .= ' ' . $this->gettext('spammoveexplanation_part3');
+		$spammoveexplanation = '<br /><span class="vexim-explanation">' . str_replace("%italicstart", "<i>", str_replace("%italicend", "</i>", $this->gettext('spammoveexplanation_part1')));
+		if ($this->config['parsefolders_script'])
+			$spammoveexplanation .= ' ' . $this->gettext('spammoveexplanation_part2');
+		$spammoveexplanation .= ' ' . $this->gettext('spammoveexplanation_part3');
 
-			$field_id = 'axel_on_movespam';
-			$input_spammove = new html_checkbox(array('name' => 'axel_on_movespam', 'id' => $field_id, 'value' => 1));
-	
-			$out .= sprintf("<tr><th><label for=\"%s\">%s</label>:</th><td>%s%s</td></tr>\n",
-						$field_id,
-						rep_specialchars_output($this->gettext('spammove')),
-						$input_spammove->show($axel_on_movespam?1:0),
-						$spammoveexplanation);
+		$field_id = 'spam_drop';
+		$input_spammove = new html_checkbox(array('name' => 'spam_drop', 'id' => $field_id, 'value' => 1));
 
-		}
-	
+		$out .= sprintf("<tr><th><label for=\"%s\">%s</label>:</th><td>%s%s</td></tr>\n",
+					$field_id,
+					rep_specialchars_output($this->gettext('spammove')),
+					$input_spammove->show($spam_drop?1:0),
+					$spammoveexplanation);
+		
 		$out .= '</table>';
 		
 		if ($this->config['parsefolders_script'] and $this->config['parsefolders_script_show_tip'])
@@ -597,7 +593,7 @@ class veximaccountadmin extends rcube_plugin
 		return $ret;  
 	}
 
-	private function _save($user,$on_avscan,$on_spamassassin,$sa_tag,$sa_refuse,$axel_on_movespam,$on_vacation,$vacation,$on_forward,$forward,$unseen,$maxmsgsize,$acts,$prefs,$vals)
+	private function _save($user,$on_avscan,$on_spamassassin,$sa_tag,$sa_refuse,$spam_drop,$on_vacation,$vacation,$on_forward,$forward,$unseen,$maxmsgsize,$acts,$prefs,$vals)
 	{
 		$rcmail = rcmail::get_instance();
 	
@@ -639,10 +635,7 @@ class veximaccountadmin extends rcube_plugin
 				}
 			}
 
-		if ($this->config['movespam_transporter']) {
-			$add_sql = '`axel_on_movespam` = ' . $this->db->quote($axel_on_movespam,'text') . ', ';
-		}
-	
+		$add_sql = '`spam_drop` = ' . $this->db->quote($spam_drop,'text') . ', ';
 		$sql = 'UPDATE `users` SET ' . $add_sql . '`on_avscan` = ' . $this->db->quote($on_avscan,'text') . ', `on_spamassassin` = ' . $this->db->quote($on_spamassassin,'text') . ', `sa_tag` = ' . $this->db->quote($sa_tag,'text') . ', `sa_refuse` = ' . $this->db->quote($sa_refuse,'text') . ', `on_vacation` = ' . $this->db->quote($on_vacation,'text') . ', `vacation` = ' . $this->db->quote($vacation,'text') . ', `on_forward` = ' . $this->db->quote($on_forward,'text') . ', `forward` = ' . $this->db->quote($forward,'text') . ', `unseen` = ' . $this->db->quote($unseen,'text') . ', `maxmsgsize` = ' . $this->db->quote($maxmsgsize,'text') . '  WHERE `username` = ' . $this->db->quote($user,'text') . ' LIMIT 1;';
 	
 		$config_error = 0;


### PR DESCRIPTION
* translated optional field "axel_on_movespam" into required field
  "spamdrop";
* removed obsoleted corresponding extra-configuration.